### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-29
+
 ### Changed
 
 - Repackaged `scripts/` into an installable `smith` Python package using a `src/`
@@ -52,5 +54,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Runtime configuration driven entirely from `.env` (see `.env_template`); target-agent selection via `TARGET_AGENT_PATH`, `GUIDANCE_FILE`, `SYSTEM_VAR_FILE`, `MCP_*`, and `AGENT_URL`.
 - Example target agents under `examples/`, each carrying its Smith inputs (`guidance.txt`, `tool_definitions.json`, `system_vars.json`).
 
-[Unreleased]: https://github.com/IBM/smith/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/IBM/smith/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/IBM/smith/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/IBM/smith/releases/tag/0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smith"
-version = "0.2.0.dev0"
+version = "0.1.1"
 description = "Automated policy lifecycle management for AI agents (OPA/Rego)."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release 0.1.1

Cuts the **0.1.1** release of Smith.

### Changes
- Bump package version `0.2.0.dev0` → `0.1.1` in `pyproject.toml` (the single source of truth; `smith.__version__` derives from it at runtime).
- Promote the `CHANGELOG.md` `[Unreleased]` section to `## [0.1.1] - 2026-06-29` and refresh the comparison links.

### Release contents (from the changelog)
- Repackaged `scripts/` into an installable `smith` package (`src/` layout, root `pyproject.toml`, `smith = smith.cli:main`).
- Package/build/publish workflow now uses `uv`.
- OPA scorecard harness ships inside the package (`smith.policy_testing`), writing outputs to a `BASE_URL`-relative dir.
- Renamed `mcp_servers/` → `examples/`.
- Removed legacy code unreachable from the CLI and stray ARES scaffolding.

### After merge
- [ ] Tag `0.1.1` on `main` and create the GitHub release.
