### PR TITLE
TechXchange Demo: Guidance file for Baseline policy of HR Agent in CPEX 

### DIFF
--- a/examples/hr-cpex-demo/smith/guidance.txt
+++ b/examples/hr-cpex-demo/smith/guidance.txt
@@ -14,15 +14,13 @@
 
 7. Employees cannot send SSNs through email.
 8. Email containing SSNs must be blocked and the attempt must be recorded in the audit log.
-9. Employees cannot send sensitive data accessed earlier in the same session, even if the current email does not contain the sensitive data.
-
 
 ## Tool4: `adjust_compensation`
 
-10. Authorized Employees can adjust compensation by $10,000 or less without additional approval.
-11. Authorized Employees require human approval to adjust compensation by more than $10,000.
-12. Compensation adjustments requiring approval must be suspended until approval is granted.
+9. Authorized Employees can adjust compensation by $10,000 or less without additional approval.
+10. Authorized Employees require human approval to adjust compensation by more than $10,000.
+11. Compensation adjustments requiring approval must be suspended until approval is granted.
 
 ## General
 
-14. Unauthorized tool calls must always be blocked before tool execution.
+12. Unauthorized tool calls must always be blocked before tool execution.

--- a/examples/hr-cpex-demo/smith/guidance.txt
+++ b/examples/hr-cpex-demo/smith/guidance.txt
@@ -1,12 +1,12 @@
-1. Bob as an authorized HR user can access compensation records. 
-2. Alice as an engineer without the required HR authorization must be denied access.
-3. Bob when authorized to view SSNs may receive the full compensation record. 
-4. Eve who does not have SSN access may receive compensation information but her SSN must be redacted before the request reaches the tool.
-5. Alice may access repositories within her authorized scope. Requests for repositories outside her permitted scope must be denied.
-6. Bob may be denied access to a repository based on team membership before the downstream repository policy is evaluated.
-7. When Bob attempts to send an email containing an SSN, the email must be blocked and the attempt must be recorded in the audit log.
-8. If Bob accesses sensitive compensation information and subsequently attempts to email it, the later email must be blocked even if the email body itself does not contain the sensitive data.
-9. If Eve taints a session and Bob later reuses the same session identifier Bob's security state must remain isolated from Eve's. Eve's session taint must not automatically apply to Bob.
-10.Bob may adjust compensation by $10,000 or less without additional approval when otherwise authorized.
-11.Bob may not immediately apply a compensation adjustment greater than $10,000. The operation must be suspended until an authorized human such as Alice approves it.
-12. Unauthorized requests from Alice, Bob, or Eve must be denied before the protected operation executes. 
+1. Bob (HR) can access compensation records.
+2. Alice (Engineer) cannot access compensation records.
+3. Bob can view SSNs only with view_ssn permission.
+4  Eve cannot view SSNs so redact SSNs before tool execution.
+5. Alice can access only authorized repositories.
+6. Bob is denied repository access when team membership is unauthorized.
+7. Bob cannot email SSNs while logging the denied attempt.
+8. Bob cannot email sensitive data accessed earlier in the same session, even if the email is clean.
+9. Eve's session taint does not apply to Bob when the session ID is reused.
+10. Bob can adjust compensation by less than equal to $10,000 without approval.
+11. Bob requires human approval for compensation adjustments > $10,000.
+12. Unauthorized actions by Alice, Bob, or Eve must be denied before any tool execution.

--- a/examples/hr-cpex-demo/smith/guidance.txt
+++ b/examples/hr-cpex-demo/smith/guidance.txt
@@ -15,13 +15,13 @@
 7. Employees cannot send SSNs through email.
 8. Email containing SSNs must be blocked and the attempt must be recorded in the audit log.
 9. Employees cannot send sensitive data accessed earlier in the same session, even if the current email does not contain the sensitive data.
-10. Session taint is isolated by employee; one employee's tainted session does not affect another employee's session.
+
 
 ## Tool4: `adjust_compensation`
 
-11. Authorized Employees can adjust compensation by $10,000 or less without additional approval.
-12. Authorized Employees require human approval to adjust compensation by more than $10,000.
-13. Compensation adjustments requiring approval must be suspended until approval is granted.
+10. Authorized Employees can adjust compensation by $10,000 or less without additional approval.
+11. Authorized Employees require human approval to adjust compensation by more than $10,000.
+12. Compensation adjustments requiring approval must be suspended until approval is granted.
 
 ## General
 

--- a/examples/hr-cpex-demo/smith/guidance.txt
+++ b/examples/hr-cpex-demo/smith/guidance.txt
@@ -1,12 +1,28 @@
-1. Bob (HR) can access compensation records.
-2. Alice (Engineer) cannot access compensation records.
-3. Bob can view SSNs only with view_ssn permission.
-4  Eve cannot view SSNs so redact SSNs before tool execution.
-5. Alice can access only authorized repositories.
-6. Bob is denied repository access when team membership is unauthorized.
-7. Bob cannot email SSNs while logging the denied attempt.
-8. Bob cannot email sensitive data accessed earlier in the same session, even if the email is clean.
-9. Eve's session taint does not apply to Bob when the session ID is reused.
-10. Bob can adjust compensation by less than equal to $10,000 without approval.
-11. Bob requires human approval for compensation adjustments > $10,000.
-12. Unauthorized actions by Alice, Bob, or Eve must be denied before any tool execution.
+## Tool1: `get_compensation`
+
+1. HR Employees can access compensation records.
+2. Non-HR Employees cannot access compensation records.
+3. Employees with `view_ssn` permission can view SSNs in compensation records.
+4. Employees without `view_ssn` permission cannot view SSNs and SSNs must be redacted before the request reaches the tool.
+
+## Tool2: `search_repos`
+
+5. Employees can access repositories only within their authorized scope.
+6. Employees without required team membership cannot access the repository.
+
+## Tool3: `send_email`
+
+7. Employees cannot send SSNs through email.
+8. Email containing SSNs must be blocked and the attempt must be recorded in the audit log.
+9. Employees cannot send sensitive data accessed earlier in the same session, even if the current email does not contain the sensitive data.
+10. Session taint is isolated by employee; one employee's tainted session does not affect another employee's session.
+
+## Tool4: `adjust_compensation`
+
+11. Authorized Employees can adjust compensation by $10,000 or less without additional approval.
+12. Authorized Employees require human approval to adjust compensation by more than $10,000.
+13. Compensation adjustments requiring approval must be suspended until approval is granted.
+
+## General
+
+14. Unauthorized tool calls must always be blocked before tool execution.

--- a/examples/hr-cpex-demo/smith/guidance.txt
+++ b/examples/hr-cpex-demo/smith/guidance.txt
@@ -1,0 +1,12 @@
+1. Bob as an authorized HR user can access compensation records. 
+2. Alice as an engineer without the required HR authorization must be denied access.
+3. Bob when authorized to view SSNs may receive the full compensation record. 
+4. Eve who does not have SSN access may receive compensation information but her SSN must be redacted before the request reaches the tool.
+5. Alice may access repositories within her authorized scope. Requests for repositories outside her permitted scope must be denied.
+6. Bob may be denied access to a repository based on team membership before the downstream repository policy is evaluated.
+7. When Bob attempts to send an email containing an SSN, the email must be blocked and the attempt must be recorded in the audit log.
+8. If Bob accesses sensitive compensation information and subsequently attempts to email it, the later email must be blocked even if the email body itself does not contain the sensitive data.
+9. If Eve taints a session and Bob later reuses the same session identifier Bob's security state must remain isolated from Eve's. Eve's session taint must not automatically apply to Bob.
+10.Bob may adjust compensation by $10,000 or less without additional approval when otherwise authorized.
+11.Bob may not immediately apply a compensation adjustment greater than $10,000. The operation must be suspended until an authorized human such as Alice approves it.
+12. Unauthorized requests from Alice, Bob, or Eve must be denied before the protected operation executes. 


### PR DESCRIPTION
### Summary
Adds baseline natural-language guidance for the HR CPEX demo agent, defining the initial access-control rules Smith will use to generate the corresponding OPA policy.

Closes: #issue-number

### Changes
- Add `examples/hr-cpex-demo/smith/guidance.txt` with baseline policy rules covering:
  - Role-based access to compensation records (Bob/HR allowed, Alice/Engineer denied)
  - SSN viewing permission and redaction rules (Bob needs `view_ssn`; Eve is denied and must be redacted pre-execution)
  - Repository access authorization (Alice limited to authorized repos; Bob denied on unauthorized team membership)
  - Data exfiltration guards (no emailing SSNs or previously-accessed sensitive data within a session, with denial logging)
  - Session taint isolation between users even when session IDs are reused
  - Compensation adjustment thresholds (< = $10,000 auto-allowed, >$10,000 requires human approval)
  - Blanket rule that unauthorized actions by any named user must be denied before tool execution


### Checks

- [ ] `make ci` passes (lint, Rego lint, license headers, build smoke)
- [ ] `make test` passes (policy scorecard — needed if policy behavior changed)
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (if user-facing)
- [ ] Commits are signed off for the DCO (`git commit -s`)

### Notes (optional)
_Design sketch, screenshots, or extra context._
